### PR TITLE
Update kaggle-computation-service.ts

### DIFF
--- a/src/services/kaggle-computation-service.ts
+++ b/src/services/kaggle-computation-service.ts
@@ -116,7 +116,7 @@ export class KaggleComputationService implements ComputationService {
         }
 
         const { error } = await KaggleApi.kernelPush(user, kernelPushRequest)
-        if (error != null) {
+        if (error != null && error != "Maximum batch GPU session count of 2 reached.") {
             throw error
         }
     }


### PR DESCRIPTION
fix error when kaggle returns "Maximum batch GPU session count of 2 reached."